### PR TITLE
Provide default child_spec/1 for Raft.StateMachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ defmodule KVStore do
 end
 ```
 
+You can automatically start a peer as part of your supervision tree as shown below. As shown here,
+when the supervisor starts, a new peer will be started with the given name. You can provide additional
+options and they will be used to customize the default config for the peer, for example, you can change
+the data directory with the `:data_dir` option.
+
+```elixir
+defmodule KVStoreSupervisor do
+  use Supervisor
+  
+  def start_link(args), do: Supervisor.start_link(__MODULE__, name: __MODULE__)
+  
+  def init(_args) do
+    children = [
+      {KVStore, [name: :"kvstore_#{Node.self}"]}
+    ]
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end
+```
+
+For the rest of this example however, we will assume you are manually starting/configuring
+peers with `Raft.start_peer/2`, rather than starting them as part of your supervision tree.
+
 Now we can start our peers. Its important to note that each peer must be
 given a unique name within the cluster. In this example we'll create
 three codes with shortnames `a`, `b`, and `c`. The Raft peers on these

--- a/lib/raft/state_machine.ex
+++ b/lib/raft/state_machine.ex
@@ -59,15 +59,15 @@ defmodule Raft.StateMachine do
               dir
           end
         File.mkdir_p!(data_dir)
-        new_args =
+        config =
           args
           |> Keyword.put(:name, name)
           |> Keyword.put(:data_dir, data_dir)
-        config = Raft.Config.new(new_args)
-        new_args = Keyword.put(new_args, :config, config)
-        %{id: unquote(caller),
-          start: {Raft, :start_peer, [unquote(caller), new_args]},
-          type: :worker}
+          |> Raft.Config.new()
+          |> Map.put(:state_machine, unquote(caller))
+        peer_name = {name, Node.self}
+        child_id = {Raft.PeerSupervisor, name}
+        Supervisor.child_spec({Raft.PeerSupervisor, {peer_name, config}}, id: child_id)
       end
 
       defoverridable [child_spec: 1]

--- a/lib/raft/state_machine.ex
+++ b/lib/raft/state_machine.ex
@@ -41,8 +41,36 @@ defmodule Raft.StateMachine do
   @callback handle_read(cmd(), state()) :: val() | {val(), state()}
 
   defmacro __using__(_) do
+    caller = __CALLER__.module
     quote location: :keep do
       @behaviour unquote(__MODULE__)
+
+      def child_spec(args) do
+        app = Application.get_application(unquote(caller))
+        name = Keyword.get(args, :name, unquote(caller))
+        data_dir =
+          case Keyword.get(args, :data_dir) do
+            nil ->
+              # Default to a unique data dir for each node and state machine
+              node_str = "#{Node.self}"
+              root_dir = Application.app_dir(app, "data")
+              Path.join([root_dir, node_str, "#{name}"])
+            dir ->
+              dir
+          end
+        File.mkdir_p!(data_dir)
+        new_args =
+          args
+          |> Keyword.put(:name, name)
+          |> Keyword.put(:data_dir, data_dir)
+        config = Raft.Config.new(new_args)
+        new_args = Keyword.put(new_args, :config, config)
+        %{id: unquote(caller),
+          start: {Raft, :start_peer, [unquote(caller), new_args]},
+          type: :worker}
+      end
+
+      defoverridable [child_spec: 1]
     end
   end
 end


### PR DESCRIPTION
- Provides sane default for child_spec/1, but overridable
- Ensures default config for state machine uses a data_dir which is
unique per-node, and per-name

This was one of the things that caught my eye when I was reimplementing a distributed process registry like Swarm on top of `raft` - when running multiple nodes via `iex`, the same default data_dir is used for all nodes and all state machines. In addition, I needed to provide a child_spec for the process, even though there is only one way to run it (start_peer). I implemented more or less this child_spec in my own application, but there is really nothing special about it at all, it should probably be the default and only overridden in those cases where one has a good reason to, rather than forcing everyone to implement the same child_spec in every state machine.

This provides an easy way to add state machines to a supervisor, it's just `{MyModule, []}` and it will automatically be started as a peer under the supervisor on boot. It also ensures that there is no friction with running multiple nodes locally for testing and development, and supports multiple state machines in the same project as well.

I probably should update the docs as part of this PR, but wanted to get your feedback first.