### PR TITLE
Don't wrap client responses in ok tuples.

### DIFF
--- a/lib/raft/state_machine/stack.ex
+++ b/lib/raft/state_machine/stack.ex
@@ -10,23 +10,23 @@ defmodule Raft.StateMachine.Stack do
   end
 
   def handle_read(:length, stack) do
-    {Enum.count(stack), stack}
+    {{:ok, Enum.count(stack)}, stack}
   end
 
   def handle_read(:all, stack) do
-    {stack, stack}
+    {{:ok, stack}, stack}
   end
 
   def handle_write({:put, item}, stack) do
     new_stack = [item | stack]
-    {Enum.count(new_stack), new_stack}
+    {{:ok, Enum.count(new_stack)}, new_stack}
   end
 
   def handle_write(:pop, [item | stack]) do
-    {item, stack}
+    {{:ok, item}, stack}
   end
 
   def handle_write(:pop, []) do
-    {:empty, []}
+    {{:ok, :empty}, []}
   end
 end

--- a/test/support/applier.ex
+++ b/test/support/applier.ex
@@ -12,7 +12,7 @@ defmodule Raft.Support.Applier do
   end
 
   def stop_applying(pid) do
-    GenServer.call(pid, :stop_applying)
+    GenServer.call(pid, :stop_applying, 20_000)
   end
 
   def init({cluster, generator}) do


### PR DESCRIPTION
This PR fixes an api bug. Before we were wrapping the return value in an `:ok` tuple. Now we just return whatever is specified in the users state machine.