### PR TITLE
Supervise rpc processes.

### DIFF
--- a/lib/raft/application.ex
+++ b/lib/raft/application.ex
@@ -5,6 +5,7 @@ defmodule Raft.Application do
 
   def start(_type, _args) do
     children = [
+      {Task.Supervisor, name: Raft.RPC.Supervisor},
       Raft.Server.Supervisor,
     ]
 

--- a/lib/raft/peer_supervisor.ex
+++ b/lib/raft/peer_supervisor.ex
@@ -7,7 +7,7 @@ defmodule Raft.PeerSupervisor do
     Supervisor.start_link(__MODULE__, {name, config}, name: sup_name(name))
   end
 
-  @spec sup_name(Raft.peer()) :: String.t
+  @spec sup_name(Raft.peer()) :: atom()
   def sup_name({name, _}) do
     sup_name(name)
   end

--- a/test/fuzzy/partitions_test.exs
+++ b/test/fuzzy/partitions_test.exs
@@ -2,6 +2,8 @@ defmodule Raft.Fuzzy.PartitionsTest do
   use ExUnit.Case, async: false
   import StreamData
 
+  @moduletag :capture_log
+
   alias Raft.Support.{
     Applier,
     Cluster,

--- a/test/raft_test.exs
+++ b/test/raft_test.exs
@@ -78,6 +78,7 @@ defmodule RaftTest do
   end
 
   @tag :focus
+  @tag :capture_log
   test "leader failure" do
     # Start all nodes
     {:ok, _s1} = Raft.start_peer(Stack, name: :s1)


### PR DESCRIPTION
After this change all of the rpc processes will be supervised tasks. This gives us a better ability to monitor the rpc processes and get insight into rpc failures. It also provides the normal benefits of supervising processes such as graceful shutdown and such.