### PR TITLE
Fixes typo in server.ex apply/2 doc

### DIFF
--- a/lib/raft/server.ex
+++ b/lib/raft/server.ex
@@ -64,7 +64,7 @@ defmodule Raft.Server do
 
   @doc """
   Applies a new log to the application state machine. This is done in a highly
-  consistent manor. This must be called on the leader or it will fail.
+  consistent manner. This must be called on the leader or it will fail.
   """
   # @spec apply(server(), term()) :: :ok | {:error, :timeout} | {:error, :not_leader}
 


### PR DESCRIPTION
I was just reading through the source code of your project and noticed this small typo. I'm trying to learn the Raft protocol so after going through the paper I decided to dig into the code. This is so well written and easy to follow ❤️ 

Would love to tackle some of the bigger issues once I become more familiar with the code base, figured you have to start somewhere :)