### PR TITLE
Fix warning: unused variable

### DIFF
--- a/lib/raft/server.ex
+++ b/lib/raft/server.ex
@@ -279,7 +279,6 @@ defmodule Raft.Server do
     if consistent?(req, state) do
       Logger.debug(fn ->
         count = Enum.count(req.entries)
-        me = state.me
         indexes = Enum.map(req.entries, & &1.index)
         "#{name(state)}: Log is consistent. Appending #{count} new entries at indexes: #{inspect indexes}"
       end)


### PR DESCRIPTION
Fix the following warning:
```
warning: variable "me" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/raft/server.ex:282: Raft.Server.follower/3
```